### PR TITLE
Merge Fix and TicketIt Integration

### DIFF
--- a/app/Http/Controllers/MergeController.php
+++ b/app/Http/Controllers/MergeController.php
@@ -15,6 +15,7 @@ use App\User;
 use Illuminate\Http\Request;
 use App\Person;
 use App\Location;
+use Kordy\Ticketit\Models\Ticket;
 use Laravel\Socialite\Facades\Socialite;
 use Illuminate\Support\Facades\DB;
 use App\Notifications\AccountMerge;
@@ -170,7 +171,7 @@ class MergeController extends Controller
         list($personID, $field) = array_pad(explode("-", $string, 2), 2, null);
         $person = Person::with('orgperson')->find($personID);
 
-        if(null !== $person) {
+        if (null !== $person) {
             return json_encode(array('status' => 'success',
                 'p' => $person,
                 'personID' => $person->personID,
@@ -194,6 +195,7 @@ class MergeController extends Controller
      * 3. update $model1->updaterID
      * 4. Take all emails, addresses, reg->regID, rf->regID on $model2 and move to $model1
      * 4b. Change the model2->person->login to "merged_$login" to avoid key conflicts
+     * 4c. Change user_id in ticketit as appropriate
      * 5. Remove duplicates:  $model2, $orgPerson, $user
      *
      */
@@ -291,6 +293,12 @@ class MergeController extends Controller
                         $m2->updaterID = $this->currentPerson->personID;
                         $m2->save();
                     }
+                    // on the off chance $m2 owns TicketIt tickets...
+                    foreach ($model2->user->tickets as $t) {
+                        $m2 = Ticket::find($t->id);
+                        $m2->user_id = $model1->personID;
+                        $m2->save();
+                    }
 
                     $o1 = OrgPerson::where([
                         ['personID', $model1->personID],
@@ -302,6 +310,8 @@ class MergeController extends Controller
                         ['orgID', $this->currentPerson->defaultOrgID]
                     ])->first();
 
+                    // if OrgStat1 (pmi_id) is set in either orgperson record, it will survive.
+                    // if there happen to be 2 OrgStat1 values, the "keeper's" OrgStat1 survives.
                     if (($o1->OrgStat1 === null || $o1->OrgStat1 == '') && isset($o2)) {
                         if ($o2->OrgStat1) {
                             $o1->OrgStat1 = $o2->OrgStat1;
@@ -324,8 +334,8 @@ class MergeController extends Controller
                     // DB::statement("update role_user set user_id = $model1->personID where user_id = $model2->personID");
 
                     $weedout = $u1->roles()->pluck('id')->toArray();
-                    foreach($u2->roles as $r){
-                        if(!in_array($r->id, $weedout)){
+                    foreach ($u2->roles as $r) {
+                        if (!in_array($r->id, $weedout)) {
                             $u1->roles()->attach($r->id);
                         }
                         $u2->roles()->detach($r->id);
@@ -353,7 +363,7 @@ class MergeController extends Controller
                     }
 
                     // Person soft-deletes require unique key 'login' to be uniquely modified
-                    $model2->login = 'merged_' . $model2->login;
+                    $model2->login = "merged_$model1->personID_" . $model2->login;
                     $model2->save();
                     $model2->delete();
 
@@ -382,7 +392,7 @@ class MergeController extends Controller
                     break;
             }
             DB::commit();
-        } catch(\Exception $e) {
+        } catch (\Exception $e) {
             DB::rollback();
             request()->session()->flash('alert-warning', trans('messages.flashes.merge_failure', ['e' => $e]));
             return back()->withInput();

--- a/app/User.php
+++ b/app/User.php
@@ -67,4 +67,9 @@ class User extends Authenticatable implements \Illuminate\Contracts\Auth\CanRese
         $person = Person::find(auth()->user()->id);
         return $this->belongsToMany(Role::class, 'role_user', 'user_id', 'role_id')->where('role_user.orgId', $person->defaultOrgID);
     }
+
+    public function tickets()
+    {
+        return $this->hasMany(\Kordy\Ticketit\Models\Ticket::class, 'user_id', 'id');
+    }
 }

--- a/resources/views/v1/auth_pages/organization/merge.blade.php
+++ b/resources/views/v1/auth_pages/organization/merge.blade.php
@@ -1,4 +1,4 @@
-<?php
+@php
 /**
  * Comment:
  * Created: 2/9/2017
@@ -35,9 +35,10 @@ switch ($letter) {
         }
         break;
 }
-$ignore_array = array('firstName', 'lastName', 'login', 'defaultOrgID', 'personID', 'locID', 'orgID');
+$ignore_array = array('firstName', 'lastName', 'login', 'defaultOrgID', 'defaultOrgPersonID', 'personID', 'locID', 'orgID');
 $suppress_array = array('creatorID', 'createDate', 'updaterID', 'updateDate', 'defaultOrgID', 'lastLoginDate', 'deleted_at', 'locNote', 'isVirtual', 'isDeleted');
-?>
+@endphp
+
 @extends('v1.layouts.auth', ['topBits' => $topBits])
 
 @section('content')
@@ -97,13 +98,13 @@ $suppress_array = array('creatorID', 'createDate', 'updaterID', 'updateDate', 'd
                                         @lang('messages.fields.pmi_type'):
                                     </td>
                                     <td style="text-align: left;">
-                                        {{ $model1->orgperson->OrgStat1 }}<br/>
-                                        {{ $model1->orgperson->OrgStat2 }}
+                                        {{ $model1->orgStat1() }}<br/>
+                                        {{ $model1->orgperson ? $model1->orgperson->OrgStat2 : null }}
                                     </td>
-                                    @if($model2 !== null)
+                                    @if($model2 !== null && $model2->orgperson !== null)
                                         <td style="text-align: left;">
-                                            {{ $model2->orgperson->OrgStat1 }}<br/>
-                                            {{ $model2->orgperson->OrgStat2 }}
+                                            {{ $model2->orgStat1() }}<br/>
+                                            {{ $model2->orgperson->OrgStat2 }}<br/>
                                         </td>
                                     @endif
                                 </tr>


### PR DESCRIPTION
- merging person records requires the ownership change of TicketIt tickets

- C:Merge:
  + update store method to account for TicketIt
  + better person->login update for non-surviving person record
- M:User: added tickets() relation to TicketIt model
- B:merge: ignore of defaultOrgPersonID and display of OrgStat1 for the models